### PR TITLE
v8.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "@survicate/analytics-react-native-survicate",
   "version": "8.0.0",
   "description": "The hassle-free way to add Segment analytics Survicate plugin to your React-Native app.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Survicate/analytics-react-native-survicate"
+  },
   "main": "lib/commonjs/index.js",
   "scripts": {
     "build": "bob build",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@survicate/analytics-react-native-survicate",
-  "version": "7.0.0",
+  "version": "8.0.0",
   "description": "The hassle-free way to add Segment analytics Survicate plugin to your React-Native app.",
   "main": "lib/commonjs/index.js",
   "scripts": {
@@ -41,11 +41,11 @@
   "homepage": "https://survicate.com",
   "peerDependencies": {
     "@segment/analytics-react-native": "*",
-    "@survicate/react-native-survicate": "^7.0.0"
+    "@survicate/react-native-survicate": "^8.0.0"
   },
   "devDependencies": {
     "@segment/analytics-react-native": "^2.17.0",
-    "@survicate/react-native-survicate": "^7.0.0",
+    "@survicate/react-native-survicate": "^8.0.0",
     "@types/jest": "^29.5.4",
     "react-native-builder-bob": "^0.40.17",
     "ts-jest": "^27.1.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1894,10 +1894,10 @@
     "@stdlib/utils-constructor-name" "^0.0.x"
     "@stdlib/utils-global" "^0.0.x"
 
-"@survicate/react-native-survicate@^7.0.0":
-  version "7.3.0"
-  resolved "https://registry.yarnpkg.com/@survicate/react-native-survicate/-/react-native-survicate-7.3.0.tgz#c9f585d028fe3488c73d6a90b6c4a2102d4ed5cc"
-  integrity sha512-azSWKvKjTY23Fr7AAkjGx6eznoniO9fRAS6IIMYMxdcz+hW7eL0FVzukF9HkabhPp/WZi/CfzqJtXbZv7eKKNg==
+"@survicate/react-native-survicate@^8.0.0":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@survicate/react-native-survicate/-/react-native-survicate-8.0.0.tgz#f1b8d2925417afbf1879f6fa67b1a247f821b38a"
+  integrity sha512-GjuI5yqfo1+nZ1gGs7D5OHcEo+qa0gK29CQp5ROpLM+Ps1aEtQVJykK+kjhwir+nZX3NHdTK/NRevkBVXFpzOg==
 
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
   version "2.0.6"


### PR DESCRIPTION
## Summary
- Bump version to 8.0.0
- Update Survicate React Native SDK peer/dev dependency to ^8.0.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)